### PR TITLE
Fix Equalized Odds definition in detection.md

### DIFF
--- a/docs/source/detection.md
+++ b/docs/source/detection.md
@@ -68,7 +68,7 @@ $$P(d = 1|Y = 1,G = m) = P(d = 1|Y = 1,G = f )$$
 
 #### Equalized Odds
 
-This definition ([Hardt, 2016](#bibliography)) combines the previous two meaning that for a classifier to satisfy Equalized Odds it is necessary that both the protected and the unprotected groups have equal TPR and FNR. Formally:
+This definition ([Hardt, 2016](#bibliography)) combines the previous two meaning that for a classifier to satisfy Equalized Odds it is necessary that both the protected and the unprotected groups have equal TPR and FPR. Formally:
 
 $$P(d = 1|Y = i,G = m) = P(d=1|Y=i,G=f), i \in \\{ 0,1 \\}$$
 


### PR DESCRIPTION
Corrected the definition of Equalized Odds to specify equal True Positive Rate (TPR) and False Positive Rate (FPR) instead of False Negative Rate (FNR).